### PR TITLE
move chai and mocha to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/frdmn/openssl-cert-tools/issues"
   },
   "homepage": "https://github.com/frdmn/openssl-cert-tools#readme",
-  "dependencies": {
+  "devDependencies": {
     "chai": "^3.3.0",
     "mocha": "^2.3.3"
   }


### PR DESCRIPTION
The `minimatch` version in Mocha 2.x [is insecure](https://nodesecurity.io/advisories/118).  This means all dependent projects of `openssl-cert-tools` will raise a security warning from [nsp](https://npmjs.com/package/nsp) if `minimatch` is installed via production dependencies (which it is).  This PR addresses the problem by moving `mocha` and `chai` into `devDependencies`.