### PR TITLE
Fix spawn buffer parsing & npm audit

### DIFF
--- a/lib/information.js
+++ b/lib/information.js
@@ -25,16 +25,20 @@ module.exports = {
 
   	var openssl = spawn('openssl', ['x509', '-noout', '-issuer', '-subject', '-dates']);
 
-    // Catch stderr
-    openssl.stderr.on('data', function (out) {
-      err = new Error(out);
+    var stderr = [];
+    var stdout = [];
 
-      // Callback and return array
-      return cb(err, infoObject);
-    });
+    openssl.stderr.on('data', stderr.push.bind(stderr));
+    openssl.stdout.on('data', stdout.push.bind(stdout));
 
-  	openssl.stdout.on('data', function (out) {
-      var data = out.toString();
+    openssl.on('close', function (code) {
+      if (code !== 0) {
+        var error = Buffer.concat(stderr).toString();
+        // Callback and return array
+        return cb(new Error(error), infoObject);
+      }
+
+      var data = Buffer.concat(stdout).toString();
 
       // Put each line into an array
       var lineArray = data.split('\n');

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/frdmn/openssl-cert-tools#readme",
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^3.1.2"
+    "mocha": "^5.2.0"
   }
 }


### PR DESCRIPTION
Previous implementation was randomly failing due depending on the stdout event split.

Also updated mocha to solve npm audit warnings.