### PR TITLE
Fix: Initialize stdout/stderr variables with empty string

### DIFF
--- a/lib/certificate.js
+++ b/lib/certificate.js
@@ -18,9 +18,8 @@ module.exports = {
    */
   getCertificate: function (host, port, cb) {
     var err,
-        data = {},
-        stderr,
-        stdout;
+        stderr = '',
+        stdout = '';
 
     var openssl = spawn('openssl', ['s_client', '-connect', host + ':' + port, '-servername', host]);
 
@@ -94,8 +93,8 @@ module.exports = {
    */
   getCertificateChain: function (host, port, cb) {
     var err,
-        stdout,
-        stderr;
+        stdout = '',
+        stderr = '';
 
     var openssl = spawn('openssl', ['s_client', '-showcerts', '-connect', host + ':' + port, '-servername', host]);
 


### PR DESCRIPTION
Should fix #17 